### PR TITLE
Keep image loaded until user unloads it

### DIFF
--- a/src/scripts/content.js
+++ b/src/scripts/content.js
@@ -1,11 +1,72 @@
-console.log('Content_Script::::');
-chrome.runtime.onMessage.addListener(function(msg, _, sendResponse) {
-  var tpl =
-  '<div id="image-extension-wrapper">' +
-      '<img id="img-placeholder" src="' + msg.imageData + '"/>'+
-  '</div>';
+function tpl(imageData){
+  return '<div id="image-extension-wrapper">' +
+            '<img id="img-placeholder" src="' + imageData + '"/>'+
+        '</div>';
+}
 
-  document.body.innerHTML += tpl;
-  var wrapper = document.getElementById('image-extension-wrapper');
-  sendResponse('ok');
+var wrapper;
+
+if (localStorage.pd_img_src){
+    document.body.innerHTML += tpl(localStorage.pd_img_src);
+    wrapper = document.getElementById('image-extension-wrapper');
+}
+
+function renderImage(msg, sendResponse) {
+  wrapper = document.getElementById('image-extension-wrapper');
+  console.log(msg);
+  if (!wrapper) {
+    document.body.innerHTML += tpl(msg.imageData);
+  } else {
+    wrapper.firstChild.src = msg.imageData;
+  }
+
+  localStorage.pd_img_src = msg.imageData;
+  localStorage.pd_file_name = msg.fileName;
+
+  sendResponse({
+    pd_img_src: msg.imageData,
+    pd_file_name: msg.fileName
+  });
+}
+
+function getLocalStorage(keys, sendResponse){
+  var data = {};
+  keys.forEach(function(k){
+    data[k] = localStorage[k];
+  });
+  sendResponse(data);
+}
+
+function setLocalStorage(data, sendResponse){
+  Object.keys(data).forEach(function(k){
+    localStorage[k] = data[k];
+  });
+  sendResponse(true);
+}
+
+function unloadImage(sendResponse){
+  var img = document.getElementById('img-placeholder');
+  img.src = '#';
+  delete localStorage.pd_file_name;
+  delete localStorage.pd_img_src;
+  sendResponse(true);
+}
+
+chrome.runtime.onMessage.addListener(function(msg, _, sendResponse) {
+  switch (msg.name){
+    case 'getLocalStorage':
+      getLocalStorage(msg.keys, sendResponse);
+      break;
+    case 'setLocalStorage':
+      setLocalStorage(msg.data, sendResponse);
+      break;
+    case 'unloadImage':
+      unloadImage(sendResponse);
+      break;
+    case 'renderImage':
+      renderImage(msg, sendResponse);
+      break;
+    default:
+      break;
+  }
 });

--- a/src/scripts/content.js
+++ b/src/scripts/content.js
@@ -13,7 +13,7 @@ if (localStorage.pd_img_src){
 
 function renderImage(msg, sendResponse) {
   wrapper = document.getElementById('image-extension-wrapper');
-  console.log(msg);
+  
   if (!wrapper) {
     document.body.innerHTML += tpl(msg.imageData);
   } else {
@@ -45,8 +45,8 @@ function setLocalStorage(data, sendResponse){
 }
 
 function unloadImage(sendResponse){
-  var img = document.getElementById('img-placeholder');
-  img.src = '#';
+  wrapper = document.getElementById('image-extension-wrapper');
+  document.body.removeChild(wrapper);
   delete localStorage.pd_file_name;
   delete localStorage.pd_img_src;
   sendResponse(true);

--- a/src/scripts/modules/loader/loader.html
+++ b/src/scripts/modules/loader/loader.html
@@ -1,9 +1,13 @@
 <div class="col-xs-12">
   <div class="row-fluid">
     <p class="lead">Load an image</p>
-    <form name="register.form" class="form">
-      <div class="form-group">
-        <input type="file" name="file" class="form-control" placeholder="File" fileread="register.file">
+    <p ng-if="loader.file.name">
+      Loaded file: {{ loader.file.name }} <span><button type="button" class="btn btn-xs btn-primary" autofocus="off" ng-click="loader.unload()">Unload</button></span>
+    </p>
+
+    <form name="loader.form" class="form">
+      <div class="form-group" ng-if="!loader.file.name">
+        <input type="file" name="file" class="form-control" placeholder="File" fileread="loader.file" on-load-file="loader.loadData">
       </div>
       <p class="note"><small>Thanks for using img.extension. Give us a like at <a href="http://www.github.com/001-whatever">Github</a> </small></p>
     </form>


### PR DESCRIPTION
The image will only be removed if a user unloads it from the extension popup.

A good question here is if this behavior should be enabled _at-eternum_ or only per sessions, meaning that if user closes the tab she will have to load the image again.
